### PR TITLE
(GH-19) set vendor to `cake-build`

### DIFF
--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <id>net.cakebuild.cakerider</id>
   <name>Cake Rider</name>
-  <vendor url="https://www.cakebuild.net">Cake</vendor>
+  <vendor url="https://www.cakebuild.net">cake-build</vendor>
 
   <!-- Product and plugin compatibility requirements -->
   <!-- https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->


### PR DESCRIPTION
fixes #19 