### PR TITLE
(GH-26) Added links to GitHub repo and releases

### DIFF
--- a/rider/plugin_description.md
+++ b/rider/plugin_description.md
@@ -7,15 +7,14 @@ in markdown, than to write the xml-encoded html into `plugin.xml`.
 
 ## The Description
 <!-- Plugin description -->
-**Cake for Rider**
+[**Cake for Rider**](https://cakebuild.net/docs/integrations/editors/rider/)
 
 Adds support for the Cake build tool in Rider.
 
 This Plugin enables [Cake](https://www.cakebuild.net) build script language support.
-
 <!-- Plugin description end -->
 
 ## Change-Notes
 <!-- Plugin changeNotes -->
-This is a very raw and very first version. You have been warned!
+[See the official GitHub releases page](https://github.com/cake-build/cake-rider/releases)
 <!-- Plugin changeNotes end -->


### PR DESCRIPTION
I modified the description to have a link back to this repo in the header and have the changenotes read "*see the official GitHub releases page*" (which is a link to ../releases)

I currently look like this in the preview:

![image](https://user-images.githubusercontent.com/349188/103487055-afb97480-4e02-11eb-9c79-e0c3da1e82aa.png)

(Note: The "plugin homepage" link points to the entry of Cake for Rider in the Marketplace, not to here)
