### PR TITLE
(GH-28) Checked and partially removed deprecated API-calls

### DIFF
--- a/rider/build.gradle.kts
+++ b/rider/build.gradle.kts
@@ -142,6 +142,7 @@ tasks {
 
     runPluginVerifier {
         ideVersions(pluginVerifierIdeVersions)
+        // reports are in ${project.buildDir}/reports/pluginVerifier - or set verificationReportsDirectory()
     }
 
     publishPlugin {

--- a/rider/gradle.properties
+++ b/rider/gradle.properties
@@ -8,7 +8,7 @@ pluginSinceBuild = 193
 pluginUntilBuild = 203.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2019.3.5, 2020.1.4, 2020.2.3, 2020.3
+pluginVerifierIdeVersions = RD-2019.3.4, RD-2020.1.4, RD-2020.2.3, RD-2020.3.2
 
 platformType = RD
 platformVersion = 2019.3

--- a/rider/src/main/kotlin/icons/CakeIcons.kt
+++ b/rider/src/main/kotlin/icons/CakeIcons.kt
@@ -3,6 +3,9 @@ package icons
 import com.intellij.openapi.util.IconLoader
 
 object CakeIcons {
+    @JvmField
     val CakeAction = IconLoader.getIcon("/icons/CakeIcon16.svg")
+
+    @JvmField
     val CakeFileType = IconLoader.getIcon("/icons/CakeIcon16.svg")
 }

--- a/rider/src/main/kotlin/net/cakebuild/run/CakeConfigurationFactory.kt
+++ b/rider/src/main/kotlin/net/cakebuild/run/CakeConfigurationFactory.kt
@@ -2,6 +2,7 @@ package net.cakebuild.run
 
 import com.intellij.execution.BeforeRunTask
 import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.execution.configurations.RunConfigurationSingletonPolicy
 import com.intellij.openapi.components.BaseState
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
@@ -11,7 +12,7 @@ import com.jetbrains.rider.build.tasks.BuildProjectBeforeRunTaskProvider
 class CakeConfigurationFactory(cakeConfigurationType: CakeConfigurationType) :
     ConfigurationFactory(cakeConfigurationType) {
 
-    override fun isConfigurationSingletonByDefault() = true
+    override fun getSingletonPolicy() = RunConfigurationSingletonPolicy.SINGLE_INSTANCE
 
     override fun createTemplateConfiguration(project: Project): CakeConfiguration {
         return CakeConfiguration(project, this)

--- a/rider/src/main/kotlin/net/cakebuild/shared/CakeBalloonNotifications.kt
+++ b/rider/src/main/kotlin/net/cakebuild/shared/CakeBalloonNotifications.kt
@@ -6,7 +6,9 @@ import com.intellij.notification.NotificationType
 import com.intellij.openapi.project.Project
 
 object CakeBalloonNotifications {
-    // after 2020.03 this can be done in pluxin.xml, see https://jetbrains.org/intellij/sdk/docs/user_interface_components/notifications.html
+    // this will raise a deprecation notice. Sadly that's unavoidable until
+    // we drop support for all versions < 2020.3.
+    // after 2020.3 this should be done in pluxin.xml, see https://jetbrains.org/intellij/sdk/docs/user_interface_components/notifications.html
     private val notificationGroup =
         NotificationGroup("Cake", NotificationDisplayType.BALLOON, true)
 

--- a/rider/src/main/kotlin/net/cakebuild/shared/CakeProject.kt
+++ b/rider/src/main/kotlin/net/cakebuild/shared/CakeProject.kt
@@ -80,7 +80,10 @@ class CakeProject(private val project: Project) {
                 CakeTaskRunMode.Debug -> DefaultDebugExecutor.getDebugExecutorInstance()
                 CakeTaskRunMode.Run -> DefaultRunExecutor.getRunExecutorInstance()
                 else -> {
-                    runManager.addConfiguration(runConfiguration, true)
+                    // this line will cause a deprecation warning.
+                    // when we drop support for versions < 2020.1 we can call the new runConfiguration.storeInDotIdeaFolder()
+                    runConfiguration.isShared = true
+                    runManager.addConfiguration(runConfiguration)
                     runManager.selectedConfiguration = runConfiguration
                     null
                 }

--- a/rider/src/main/kotlin/net/cakebuild/shared/CakeProject.kt
+++ b/rider/src/main/kotlin/net/cakebuild/shared/CakeProject.kt
@@ -81,7 +81,8 @@ class CakeProject(private val project: Project) {
                 CakeTaskRunMode.Run -> DefaultRunExecutor.getRunExecutorInstance()
                 else -> {
                     // this line will cause a deprecation warning.
-                    // when we drop support for versions < 2020.1 we can call the new runConfiguration.storeInDotIdeaFolder()
+                    // when we drop support for versions < 2020.1
+                    // we can call the new runConfiguration.storeInDotIdeaFolder()
                     runConfiguration.isShared = true
                     runManager.addConfiguration(runConfiguration)
                     runManager.selectedConfiguration = runConfiguration

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -11,7 +11,7 @@
   <extensions defaultExtensionNs="com.intellij">
     <fileType name="Cake" language="Cake" extensions="cake" implementationClass="net.cakebuild.fileTypes.CakeFileType" />
     <configurationType implementation="net.cakebuild.run.CakeConfigurationType" id="Cake" />
-    <toolWindow anchor="right" id="Cake Tasks" icon="/icons/CakeIcon13.svg" factoryClass="net.cakebuild.toolwindow.CakeTasksWindowFactory" />
+    <toolWindow anchor="right" id="Cake Tasks" icon="CakeIcons.CakeAction" factoryClass="net.cakebuild.toolwindow.CakeTasksWindowFactory" />
     <projectConfigurable parentId="build" instance="net.cakebuild.settings.CakeGeneralSettingsConfigurable"
                          id="net.cakebuild.settings.cake" displayName="Cake" nonDefaultProject="false" />
     <projectConfigurable parentId="net.cakebuild.settings.cake" instance="net.cakebuild.settings.CakeRunnerSettingsConfigurable"


### PR DESCRIPTION
We're testing the codebase against four versions of Rider: `RD-2019.3.4`, `RD-2020.1.4`, `RD-2020.2.3` and `RD-2020.3.2`

There were four calls to deprecated APIs. 
* Two were removed (rather, replaced by the correct calls.)
* One could not be resolved and will remain until we drop support for versions < `2020.3` (I commented that call suitably)
* One could be replaced, however the replacement will also raise a deprecation warning until we drop support for versions < `2020.1` (also, I commented that call)

fixes #28 