### PR TITLE
(GH-50) fixed storing of the script path

### DIFF
--- a/rider/src/main/kotlin/net/cakebuild/run/CakeConfigurationOptions.kt
+++ b/rider/src/main/kotlin/net/cakebuild/run/CakeConfigurationOptions.kt
@@ -11,7 +11,7 @@ class CakeConfigurationOptions : RunConfigurationOptions() {
         set(v) { storedTaskName.setValue(this, v) }
 
     private val storedScriptPath: StoredProperty<String?> =
-        string("build.cake").provideDelegate(this, "file")
+        string("build.cake").provideDelegate(this, "scriptPath")
     var scriptPath: String?
         get() = storedScriptPath.getValue(this)
         set(v) { storedScriptPath.setValue(this, v) }


### PR DESCRIPTION
In essence: Do not use "file" as a stored property.

fixes #50 