### PR TITLE
(GH-69) added an ErrorReportSubmitter

### DIFF
--- a/rider/src/main/kotlin/net/cakebuild/shared/GitHubErrorReporter.kt
+++ b/rider/src/main/kotlin/net/cakebuild/shared/GitHubErrorReporter.kt
@@ -1,0 +1,112 @@
+package net.cakebuild.shared
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.diagnostic.ErrorReportSubmitter
+import com.intellij.openapi.diagnostic.IdeaLoggingEvent
+import com.intellij.openapi.diagnostic.SubmittedReportInfo
+import com.intellij.openapi.diagnostic.SubmittedReportInfo.SubmissionStatus.FAILED
+import com.intellij.openapi.diagnostic.SubmittedReportInfo.SubmissionStatus.NEW_ISSUE
+import com.intellij.util.Consumer
+import java.awt.Component
+import java.net.URLEncoder
+
+// Most of this was heavily inspired by
+// https://github.com/exigow/intellij-gdscript/ ... /ReportSubmitter.kt
+// and is there licensed under MIT by Jakub Błach (@exigow)
+
+class GitHubErrorReporter : ErrorReportSubmitter() {
+    override fun getReportActionText() = "Create an issue on GitHub"
+
+    @Suppress("TooGenericExceptionCaught")
+    override fun submit(
+        events: Array<out IdeaLoggingEvent>,
+        additionalInfo: String?,
+        parentComponent: Component,
+        consumer: Consumer<SubmittedReportInfo>
+    ): Boolean {
+
+        try {
+            if (events.isNotEmpty()) {
+                val event = events.first()
+                val issue = collectIssueDetails(event, additionalInfo)
+                submitOnGithub(issue)
+            }
+        } catch (e: Exception) {
+            consumer.consume(SubmittedReportInfo(FAILED))
+            return false
+        }
+        consumer.consume(SubmittedReportInfo(NEW_ISSUE))
+        return true
+    }
+
+    private fun collectIssueDetails(event: IdeaLoggingEvent, additionalInfo: String?) =
+        Report(
+            title = event.throwableText.lines().first(),
+            pluginVersion = discoverPluginVersion(),
+            ideVersion = discoverIdeaVersion(),
+            additionalInfo = additionalInfo,
+            stacktrace = event.throwableText
+        )
+
+    private fun discoverPluginVersion() =
+        (pluginDescriptor as? IdeaPluginDescriptor)?.version
+
+    private fun discoverIdeaVersion() =
+        ApplicationInfo.getInstance().build.toString()
+
+    private fun submitOnGithub(report: Report) {
+        val markdown = MarkdownDescriptionBaker.bake(report)
+        val title = report.title ?: "no title"
+        val url = GithubLinkGenerator.generateUrl(title, markdown)
+        BrowserUtil.browse(url)
+    }
+
+    private object GithubLinkGenerator {
+        fun generateUrl(title: String, body: String): String {
+            val encodedTitle = encode(title)
+            val encodedBody = encode(body)
+            return "https://github.com/cake-build/cake-rider/issues/new" +
+                "?labels=Bug" +
+                "&title=$encodedTitle" +
+                "&body=$encodedBody"
+        }
+
+        private fun encode(text: String) =
+            URLEncoder.encode(text, "UTF-8")
+    }
+
+    private object MarkdownDescriptionBaker {
+        fun bake(report: Report) = createEntries(report)
+            .filterValues { it != null }
+            .map { bakeAttribute(it.key, it.value!!) }
+            .joinToString("\n")
+
+        private fun createEntries(report: Report) = mapOf(
+            "Plugin version" to report.pluginVersion,
+            "IDE version" to report.ideVersion,
+            "Additional information" to report.additionalInfo,
+            "Exception" to report.title,
+            "Stacktrace" to report.stacktrace
+        )
+
+        private fun bakeAttribute(label: String, text: String) =
+            if (isMultiline(text)) {
+                "$label:\n```text\n$text\n```"
+            } else {
+                "$label: ```$text```"
+            }
+
+        private fun isMultiline(text: String) =
+            text.lines().size != 1
+    }
+
+    private data class Report(
+        val title: String?,
+        val pluginVersion: String?,
+        val ideVersion: String?,
+        val additionalInfo: String?,
+        val stacktrace: String?
+    )
+}

--- a/rider/src/main/resources/META-INF/plugin.xml
+++ b/rider/src/main/resources/META-INF/plugin.xml
@@ -18,7 +18,8 @@
                          id="net.cakebuild.settings.cake.runner.paths" displayName="Search paths" nonDefaultProject="false" />
     <projectConfigurable parentId="net.cakebuild.settings.cake" instance="net.cakebuild.settings.CakeRunnerSettingsConfigurable"
                          id="net.cakebuild.settings.cake.runner" displayName="Runner" nonDefaultProject="false" />
-    <projectService serviceImplementation="net.cakebuild.settings.CakeSettings"/>
+    <projectService serviceImplementation="net.cakebuild.settings.CakeSettings" />
+    <errorHandler implementation="net.cakebuild.shared.GitHubErrorReporter" />
   </extensions>
 
   <actions>


### PR DESCRIPTION
which will open the "new issue" page on
GitHub to let a user create the issue there.

fixes #69 

This will create from an error-page like this:
![image](https://user-images.githubusercontent.com/349188/105099104-6bd59900-5aab-11eb-8a9b-50913ebc0eca.png)

a pre-filled issue page like this:
![image](https://user-images.githubusercontent.com/349188/105099187-8d368500-5aab-11eb-94fe-3c41ee7ea31d.png)
