### PR TITLE
(GH-78) added environment expansion to Cake runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ It is now possible to ensure Cake .NET Tool is installed using a before run acti
 
 ![Ensure Cake .NET Tool in before run actions](./images/beforeRunAction-ensureTool.png)
 
+#### Modified Cake runner settings
+
+The Cake runner settings are now able to process environment variables. Use a specific variable like this: `${VARIABLE}` and the environment variable will be expanded when the runner is called.
+
+Defaults for the Cake runner have changed: Default for Cake runner is now `~/.dotnet/tools/dotnet-cake` and on windows the default is `${USERPROFILE}\.dotnet\tools\dotnet-cake.exe`
+
 ## Discussion
 
 If you have questions, search for an existing one, or create a new discussion on the Cake GitHub repository.

--- a/rider/src/main/kotlin/net/cakebuild/run/CakeConfiguration.kt
+++ b/rider/src/main/kotlin/net/cakebuild/run/CakeConfiguration.kt
@@ -34,17 +34,7 @@ class CakeConfiguration(project: Project, factory: CakeConfigurationFactory) :
             return object : CommandLineState(environment) {
                 override fun startProcess(): ProcessHandler {
                     val settings = CakeSettings.getInstance(project)
-                    val os = System.getProperty("os.name")
-                    var exe = settings.cakeRunner
-                    settings.cakeRunnerOverrides.forEach forEach@{
-                        val regex = Regex(it.key, RegexOption.IGNORE_CASE)
-                        if (regex.matches(os)) {
-                            log.trace("os $os matches regex ${it.key}")
-                            exe = it.value
-                            return@forEach
-                        }
-                    }
-                    log.info("cake runner is set to $exe")
+                    val runner = settings.getCurrentCakeRunner()
                     val options = options
                     val fileSystems = FileSystems.getDefault()
                     val scriptPath = fileSystems
@@ -60,8 +50,9 @@ class CakeConfiguration(project: Project, factory: CakeConfigurationFactory) :
                     val commandLine = GeneralCommandLine()
                         .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
                         .withWorkDirectory(scriptPath.parent.toString())
-                        .withExePath(exe)
+                        .withExePath(runner)
                         .withParameters(arguments)
+                    log.trace("calling cake: ${commandLine.commandLineString}")
                     val processHandler = ProcessHandlerFactory.getInstance().createColoredProcessHandler(commandLine)
                     ProcessTerminatedListener.attach(processHandler)
                     return processHandler

--- a/rider/src/main/kotlin/net/cakebuild/settings/CakeSettings.kt
+++ b/rider/src/main/kotlin/net/cakebuild/settings/CakeSettings.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.util.xmlb.XmlSerializerUtil
 import net.cakebuild.shared.Constants
@@ -19,13 +20,39 @@ class CakeSettings : PersistentStateComponent<CakeSettings> {
         }
     }
 
+    private val log = Logger.getInstance(CakeSettings::class.java)
+
     var cakeFileExtension = "cake"
     var cakeTaskParsingRegex = "Task\\s*?\\(\\s*?\"(.*?)\"\\s*?\\)"
     var cakeVerbosity = "normal"
-    var cakeRunner = "dotnet-cake"
-    var cakeRunnerOverrides = mapOf(Pair("^.*windows.*$", "dotnet-cake.exe"))
+    var cakeRunner = "~/.dotnet/tools/dotnet-cake"
+    var cakeRunnerOverrides = mapOf(Pair("^.*windows.*$", "\${USERPROFILE}\\.dotnet\\tools\\dotnet-cake.exe"))
     var cakeScriptSearchPaths: Collection<String> = mutableListOf(".")
     var cakeScriptSearchIgnores: Collection<String> = mutableListOf(".*/tools/.*")
+
+    fun getCurrentCakeRunner(): String {
+        val os = System.getProperty("os.name")
+        var runner = cakeRunner
+        cakeRunnerOverrides.forEach forEach@{
+            val regex = Regex(it.key, RegexOption.IGNORE_CASE)
+            if (regex.matches(os)) {
+                log.trace("os $os matches regex ${it.key}")
+                runner = it.value
+                return@forEach
+            }
+        }
+
+        val variableRegex = Regex("\\\$\\{([^}]+)}")
+        runner = runner.replace(variableRegex) {
+            val varName = it.groupValues[1]
+            val varValue = System.getenv(varName) ?: ""
+            log.trace("resolved environment variable $varName to $varValue")
+            varValue
+        }
+
+        log.trace("resolved Cake runner to $runner")
+        return runner
+    }
 
     override fun getState(): CakeSettings {
         return this


### PR DESCRIPTION
Environment variable can now be inserted into the Cake runner settings.
A variable needs to written like this: ${VARIABLE_NAME} to be
automatically expanded. To that end I "centralized" the
calculation of the actual runner into CakeSettings.

Also changed the defaults for Cake runner to
~/.dotnet/tools/dotnet-cake (globally) and
${USERPROFILE}\.dotnet\tools\dotnet-cake.exe for windows.

fixes #78 