### PR TITLE
Bump detekt-formatting and io.gitlab.arturbosch.detekt from 1.15.0 to 1.16.0

### DIFF
--- a/rider/build.gradle.kts
+++ b/rider/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
     id("org.jetbrains.changelog") version "1.1.2"
     // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
-    id("io.gitlab.arturbosch.detekt") version "1.15.0"
+    id("io.gitlab.arturbosch.detekt") version "1.16.0"
     // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
     id("org.jlleitschuh.gradle.ktlint") version "10.0.0"
 }

--- a/rider/src/main/kotlin/net/cakebuild/shared/GitHubErrorReporter.kt
+++ b/rider/src/main/kotlin/net/cakebuild/shared/GitHubErrorReporter.kt
@@ -5,6 +5,7 @@ import com.intellij.ide.plugins.IdeaPluginDescriptor
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.diagnostic.ErrorReportSubmitter
 import com.intellij.openapi.diagnostic.IdeaLoggingEvent
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.diagnostic.SubmittedReportInfo
 import com.intellij.openapi.diagnostic.SubmittedReportInfo.SubmissionStatus.FAILED
 import com.intellij.openapi.diagnostic.SubmittedReportInfo.SubmissionStatus.NEW_ISSUE
@@ -17,6 +18,8 @@ import java.net.URLEncoder
 // and is there licensed under MIT by Jakub Błach (@exigow)
 
 class GitHubErrorReporter : ErrorReportSubmitter() {
+    private val log = Logger.getInstance(GitHubErrorReporter::class.java)
+
     override fun getReportActionText() = "Create an issue on GitHub"
 
     @Suppress("TooGenericExceptionCaught")
@@ -34,6 +37,7 @@ class GitHubErrorReporter : ErrorReportSubmitter() {
                 submitOnGithub(issue)
             }
         } catch (e: Exception) {
+            log.error("Error submitting issue to GitHub.", e)
             consumer.consume(SubmittedReportInfo(FAILED))
             return false
         }


### PR DESCRIPTION
supersedes #92, #93 and fixes the ensuing warning.