### PR TITLE
(GH-77) set pluginUntilBuild to 2021.1

### DIFF
--- a/rider/gradle.properties
+++ b/rider/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = net.cakebuild
 pluginName_ = cake-rider
 pluginVersion = 0.1.0-alpha.1
 pluginSinceBuild = 193
-pluginUntilBuild = 203.*
+pluginUntilBuild = 211.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
 pluginVerifierIdeVersions = RD-2019.3.4, RD-2020.1.4, RD-2020.2.3, RD-2020.3.2


### PR DESCRIPTION
this does not really "support 2021.1" but rather enables the plugin for 2021.1.
This is a first step for #77 