### PR TITLE
(GH-113) added OperatingSystem and limited

### DIFF
--- a/rider/build.gradle.kts
+++ b/rider/build.gradle.kts
@@ -119,7 +119,7 @@ tasks {
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription(
             closure {
-                File("./plugin_description.md").readText().lines().run {
+                rootDir.resolve("./plugin_description.md").readText().lines().run {
                     val start = "<!-- Plugin description -->"
                     val end = "<!-- Plugin description end -->"
 
@@ -135,7 +135,7 @@ tasks {
 
         changeNotes(
             closure {
-                File("./plugin_description.md").readText().lines().run {
+                rootDir.resolve("./plugin_description.md").readText().lines().run {
                     val start = "<!-- Plugin changeNotes -->"
                     val end = "<!-- Plugin changeNotes end -->"
 


### PR DESCRIPTION
StackTrace to 5000 chars.
For long StackTraces a "please add StackTrace here, manually" hint
appears which is not ideal but gets the job done.

For the future we should either add some gh-api access (Octokit)
which would mean the user needs to provide OAuth tokens or something..
Alternatively we could host a small web service somewhere to create an
issue in GitHub anonymously (rather: Under some bot-account).

fixes #113 