### PR TITLE
(GH-161) set pluginUntilBuild to 212.*

### DIFF
--- a/src/rider/gradle.properties
+++ b/src/rider/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = net.cakebuild
 pluginName = cake-rider
 pluginVersion = 0.1.0-alpha.1
 pluginSinceBuild = 202
-pluginUntilBuild = 211.*
+pluginUntilBuild = 212.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 # or https://data.services.jetbrains.com/products?fields=name,releases.downloads,releases.version,releases.build,releases.type&code=RD


### PR DESCRIPTION
This enables installing the plugin in Rider 2021.2.*
However, since pluginVerifier currently does not run
with 2021.2-EAP it has not been added to pluginVerifierIdeVersions

fixes #161 