### PR TITLE
(GH-201) enabled 2021.3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,12 +18,13 @@ build: off
 
 environment:
   JAVA_HOME: C:\Program Files\Java\jdk11
-  PATH: "%JAVA_HOME%\bin;%PATH%"
   #PUBLISH_TOKEN: token to JB-Marketplace for publishing
 
 
 build_script:
-  - ps: .\build.ps1 --target=CI
+  - ps: |
+      $env:Path="$env:JAVA_HOME\bin;$env:Path"
+      .\build.ps1 --target=CI
 
 cache:
   - "tools -> recipe.cake"

--- a/docs/input/docs/integrations/editors/rider/index.cshtml
+++ b/docs/input/docs/integrations/editors/rider/index.cshtml
@@ -24,7 +24,7 @@ RedirectFrom: docs/editors/rider
 
 <div class="alert alert-info">
     <p>
-        The <a href="https://plugins.jetbrains.com/plugin/15729-cake-rider" target="_blank">Cake plugin for Rider</a> supports Rider version 2020.2 and newer.
+        The <a href="https://plugins.jetbrains.com/plugin/15729-cake-rider" target="_blank">Cake plugin for Rider</a> supports Rider version 2021.2 and newer.
     </p>
 </div>
 

--- a/src/dotnet/cake-rider/Templates/BoolTemplateProviders.cs
+++ b/src/dotnet/cake-rider/Templates/BoolTemplateProviders.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
-using JetBrains.ReSharper.Host.Features.ProjectModel.ProjectTemplates.DotNetExtensions;
-using JetBrains.ReSharper.Host.Features.ProjectModel.ProjectTemplates.DotNetTemplates;
+using JetBrains.Rider.Backend.Features.ProjectModel.ProjectTemplates.DotNetExtensions;
+using JetBrains.Rider.Backend.Features.ProjectModel.ProjectTemplates.DotNetTemplates;
 using JetBrains.Rider.Model;
 
 namespace net.cakebuild.Templates

--- a/src/dotnet/cake-rider/Templates/ParameterProvider.cs
+++ b/src/dotnet/cake-rider/Templates/ParameterProvider.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using JetBrains.Application;
-using JetBrains.ReSharper.Host.Features.ProjectModel.ProjectTemplates.DotNetExtensions;
+using JetBrains.Rider.Backend.Features.ProjectModel.ProjectTemplates.DotNetExtensions;
 
 namespace net.cakebuild.Templates
 {

--- a/src/dotnet/cake-rider/Templates/TextTemplateProviders.cs
+++ b/src/dotnet/cake-rider/Templates/TextTemplateProviders.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using JetBrains.Annotations;
-using JetBrains.ReSharper.Host.Features.ProjectModel.ProjectTemplates.DotNetExtensions;
-using JetBrains.ReSharper.Host.Features.ProjectModel.ProjectTemplates.DotNetTemplates;
+using JetBrains.Rider.Backend.Features.ProjectModel.ProjectTemplates.DotNetExtensions;
+using JetBrains.Rider.Backend.Features.ProjectModel.ProjectTemplates.DotNetTemplates;
 using JetBrains.Rider.Model;
 
 namespace net.cakebuild.Templates

--- a/src/dotnet/cake-rider/cake-rider.csproj
+++ b/src/dotnet/cake-rider/cake-rider.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net461</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
         <AssemblyName>cake-rider</AssemblyName>
         <RootNamespace>net.cakebuild</RootNamespace>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -11,7 +11,7 @@
     
     <PropertyGroup>
         <!-- will be injected by gradle at build -->
-        <SdkVersion Condition="'$(SdkVersion)' == ''">2020.1.1</SdkVersion>
+        <SdkVersion Condition="'$(SdkVersion)' == ''">2021.2.1</SdkVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/rider/gradle.properties
+++ b/src/rider/gradle.properties
@@ -4,15 +4,15 @@
 pluginGroup = net.cakebuild
 pluginName = cake-rider
 pluginVersion = 0.1.0-alpha.1
-pluginSinceBuild = 203
-pluginUntilBuild = 212.*
+pluginSinceBuild = 212
+pluginUntilBuild = 213.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 # or https://data.services.jetbrains.com/products?fields=name,releases.downloads,releases.version,releases.build,releases.type&code=RD
-pluginVerifierIdeVersions = RD-2020.3.2,RD-2021.1.3,RD-2021.2.1
+pluginVerifierIdeVersions = RD-2021.2.1,RD-2021.3-EAP3
 
 platformType = RD
-platformVersion = 2020.3.2
+platformVersion = 2021.2.1
 platformDownloadSources = true
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/rider/src/main/kotlin/net/cakebuild/run/CakeConfigurationFactory.kt
+++ b/src/rider/src/main/kotlin/net/cakebuild/run/CakeConfigurationFactory.kt
@@ -19,6 +19,10 @@ class CakeConfigurationFactory(cakeConfigurationType: CakeConfigurationType) :
     }
 
     override fun getName(): String {
+        return id
+    }
+
+    override fun getId(): String {
         return "Cake configuration factory"
     }
 


### PR DESCRIPTION
Due to a breaking change in JetBrains.Rider.SDK compatibility
to all versions before 2021.2 had to be dropped.

fixes #201 