### PR TITLE
(#283) update gradle.properties to support 2022.3-EAP

### DIFF
--- a/src/rider/.idea/kotlinc.xml
+++ b/src/rider/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.6.21" />
+    <option name="version" value="1.7.10" />
   </component>
 </project>

--- a/src/rider/gradle.properties
+++ b/src/rider/gradle.properties
@@ -5,11 +5,11 @@ pluginGroup = net.cakebuild
 pluginName = cake-rider
 pluginVersion = 0.1.0-alpha.1
 pluginSinceBuild = 222
-pluginUntilBuild = 222.*
+pluginUntilBuild = 223.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 # or https://data.services.jetbrains.com/products?fields=name,releases.downloads,releases.version,releases.build,releases.type&code=RD
-pluginVerifierIdeVersions = RD-2022.2
+pluginVerifierIdeVersions = RD-2022.2,RD-2022.3-EAP1
 
 platformType = RD
 platformVersion = 2022.2

--- a/src/rider/src/main/kotlin/net/cakebuild/toolwindow/CakeTasksWindowFactory.kt
+++ b/src/rider/src/main/kotlin/net/cakebuild/toolwindow/CakeTasksWindowFactory.kt
@@ -8,7 +8,7 @@ import com.intellij.ui.content.ContentFactory
 
 class CakeTasksWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-        val contentFactory = ContentFactory.SERVICE.getInstance()
+        val contentFactory = ContentFactory.getInstance()
         val view = CakeTasksWindow(project)
         val content = contentFactory.createContent(view, "", false)
         toolWindow.contentManager.addContent(content)


### PR DESCRIPTION
Also removed one deprecated usage in CakeTasksWindowFactory

closes #283 