### PR TITLE
update cake.intellij.recipe to 0.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        #os: [ windows-2022, ubuntu-22.04, macos-12 ]
-        os: [ windows-2022, macos-12 ]
+        os: [ windows-2022, ubuntu-22.04, macos-12 ]
 
     steps:
       - name: Checkout the requested branch

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:?package=Cake.IntelliJ.Recipe&version=0.2.4
+#load nuget:?package=Cake.IntelliJ.Recipe&version=0.3.0
 
 Environment.SetVariableNames(
   githubTokenVariable: "GITHUB_PAT"
@@ -14,6 +14,8 @@ IntelliJBuildParameters.SetParameters(
   marketplaceId: "15729-cake-rider",
   webLinkRoot: "", // do *not* create a virtual directory for wyam docs. This setting will break gh-pages. (But work for preview)
   wyamConfigurationFile: MakeAbsolute((FilePath)"docs/wyam.config"),
+  shouldRunPluginVerifier: !IsRunningOnLinux(),
+  intelliJAnalyzerTasks: new[]{ "detekt", "verifyPlugin" }, // skip ktlintCheck for now
   preferredBuildProviderType: BuildProviderType.GitHubActions,
   preferredBuildAgentOperatingSystem: PlatformFamily.Windows
 );

--- a/src/rider/build.gradle.kts
+++ b/src/rider/build.gradle.kts
@@ -275,10 +275,6 @@ tasks {
     //    exclude("**/gen/**", "**/*.Generated.kt")
     //}
 
-    register("ktlintCheck") {
-        // mock task, since we disabled the "original"
-    }
-
     patchPluginXml {
         version.set(properties("pluginVersion"))
         sinceBuild.set(properties("pluginSinceBuild"))


### PR DESCRIPTION
re-enable running on linux since we now can disable pluginVerifier on linux using the new shouldRunPluginVerifier

removed the mocked ktlintCheck task, since we now can disable that using the new intelliJAnalyzerTasks